### PR TITLE
Allow multiline template strings

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -115,7 +115,7 @@ syntax cluster javascriptStatement             contains=javascriptBlock,javascri
 syntax match   javascriptTemplateSubstitution  contained /\${\w\+}/
 syntax region  javascriptString                start=/"/  skip=/\\\\\|\\"\|\\\n/  end=/"\|$/
 syntax region  javascriptString                start=/'/  skip=/\\\\\|\\'\|\\\n/  end=/'\|$/
-syntax region  javascriptTemplate              start=/`/  skip=/\\\\\|\\`\|\\\n/  end=/`\|$/ contains=javascriptTemplateSubstitution
+syntax region  javascriptTemplate              start=/`/  skip=/\\\\\|\\`\|\n/  end=/`\|$/ contains=javascriptTemplateSubstitution
 " syntax match   javascriptTemplateTag           /\k\+/ nextgroup=javascriptTemplate
 
 syntax match   javascriptNumber                /\<0[bB][01]\+\>/


### PR DESCRIPTION
Allows the following syntax:

```
var template = `hello
  world`;
```

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings