### PR TITLE
remove yield from javascriptReserved

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -162,7 +162,7 @@ syntax keyword javascriptReserved              containedin=ALLBUT,@javascriptNoR
 "import,javascriptRegexpString,javascriptPropertyName
 syntax keyword javascriptReserved              containedin=ALLBUT,@javascriptNoReserved in instanceof let new return super
 syntax keyword javascriptReserved              containedin=ALLBUT,@javascriptNoReserved switch throw try typeof var
-syntax keyword javascriptReserved              containedin=ALLBUT,@javascriptNoReserved void while with yield
+syntax keyword javascriptReserved              containedin=ALLBUT,@javascriptNoReserved void while with
 
 syntax keyword javascriptReserved              containedin=ALLBUT,@javascriptNoReserved enum implements package protected static
 syntax keyword javascriptReserved              containedin=ALLBUT,@javascriptNoReserved interface private public abstract boolean


### PR DESCRIPTION
This change makes it so that assignment to variables from yielded statements do not cause the yield world to be highlighted as an error.  Since it is already in the `javascriptStatementKeyword` group it still gets highlighted.

![bad highlighting demo](http://files.slingingcode.com/image/162J1L1T0V0w/Image%202015-04-26%20at%201.14.00%20PM.png)