### PR TITLE
Fix JSDoc inside object literals

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -57,12 +57,12 @@ syntax match   shellbang "^#!.*iojs\>"
 syntax keyword javascriptCommentTodo           contained TODO FIXME XXX TBD
 syntax match   javascriptLineComment           "//.*" contains=@Spell,javascriptCommentTodo
 syntax region  javascriptComment               start="/\*"  end="\*/" contains=@Spell,javascriptCommentTodo extend
-syntax cluster javascriptComments              contains=javascriptComment,javascriptLineComment
+syntax cluster javascriptComments              contains=javascriptDocComment,javascriptComment,javascriptLineComment
 
 "JSDoc
 syntax case ignore
 
-syntax region  javascriptDocComment            matchgroup=javascriptComment start="/\*\*"  end="\*/" contains=javascriptDocNotation,javascriptCommentTodo,@Spell fold keepend
+syntax region  javascriptDocComment            start="/\*\*"  end="\*/" contains=javascriptDocNotation,javascriptCommentTodo,@Spell fold keepend
 syntax match   javascriptDocNotation           contained /@/ nextgroup=javascriptDocTags
 
 syntax keyword javascriptDocTags               contained constant constructor constructs function ignore inner private public readonly static


### PR DESCRIPTION
Hello, complete VIM syntax n00b here.

JSDoc highlighting wasn't working for me inside `javascriptObjectLiteral` regions, so my test file here was only highlighting properly in the first instance, but not the other two:

```
/**
 * the thing goes here
 *
 * the second paragraph of stuff
 *
 * @private
 * @param {Custom.object.Here} thing the thing
 * @return {Object} muh
 */
function foo() {
    // ...
}

// this is the type of thing I have all over in the project I'm working on
defineSomeObject({
    /**
     * the thing goes here
     *
     * the second paragraph of stuff
     *
     * @private
     * @param {Custom.object.Here} thing the thing
     * @return {Object} muh
     */
    thing: function() {
    },

    /** @return {String} one-liner */
    other: function() {}
});

// raw object literal assignment for comparison
var bar = {
    /**
     * the thing goes here
     *
     * the second paragraph of stuff
     *
     * @private
     * @param {Custom.object.Here} thing the thing
     * @return {Object} muh
     */
    thing: function() {
    },

    /** @return {String} one-liner */
    other: function() {}
};
```

I changed the syntax file such that `javascriptDocComment` is no longer a `matchgroup` in `javascriptComment`. This feels sort of kludgey because the previous structure makes logical sense, and `javascriptObjectLiteral` already includes `javascriptComments`. I installed [vim-hilinks](https://github.com/kergoth/vim-hilinks) to investigate; for some reason the JSDoc comments were only parsing as `javascriptComment` and not matching `javascriptDocComment` like I would have thought. Perhaps VIM simply wasn't running those comments through the `matchgroup`? I have very little understanding of VIM syntax files (i.e., just enough to do what I've done here :-P ).

Further, this change would seem to introduce ambiguity in the match resolution process because JSDoc comments now match `javascriptComment` +and+ `javascriptDocComment`. I don't know if that sort of thing is brittle in the VIM syntax world.

There's probably a better way of handling it, but all that said, it seems to work on all the project files I've tested this against.
