### PR TITLE
Fix problem with multiple filetypes

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -41,7 +41,7 @@ endif
 
 "Dollar sign is permitted anywhere in an identifier
 setlocal iskeyword-=$
-if &filetype == 'javascript'
+if &filetype =~ 'javascript'
   setlocal iskeyword+=$
   syntax cluster htmlJavaScript                 contains=TOP
 endif


### PR DESCRIPTION
This enables correct highlighting when 'filetype' is set to multiple filetypes, like 'javascript.jsx'.

Before (no htmlJavaScript cluster, so don't highlight correctly in blocks):
![2015-05-08 15 24 13](https://cloud.githubusercontent.com/assets/433373/7531547/900d813c-f596-11e4-83e0-e95057ab14c3.png)

After:
![2015-05-08 15 23 23](https://cloud.githubusercontent.com/assets/433373/7531552/966d8db0-f596-11e4-8085-524b63344747.png)
