### PR TITLE
fix: syntax for anonymous generator functions

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -268,7 +268,7 @@ syntax keyword javascriptAsyncFuncKeyword      async await
 " syntax keyword javascriptFuncKeyword           function nextgroup=javascriptFuncName,javascriptFuncArg skipwhite
 syntax keyword javascriptFuncKeyword           function nextgroup=javascriptAsyncFunc,javascriptSyncFunc
 syntax match   javascriptSyncFunc              contained // nextgroup=javascriptFuncName,javascriptFuncArg skipwhite skipempty
-syntax match   javascriptAsyncFunc             contained /*/ nextgroup=javascriptFuncName,javascriptFuncArg skipwhite skipempty
+syntax match   javascriptAsyncFunc             contained /\s*\*\s*/ nextgroup=javascriptFuncName,javascriptFuncArg skipwhite skipempty
 syntax match   javascriptFuncName              contained /[a-zA-Z_$]\k*/ nextgroup=javascriptFuncArg skipwhite
 syntax match   javascriptFuncArg               contained /([^()]*)/ contains=javascriptParens,javascriptFuncKeyword,javascriptFuncComma nextgroup=javascriptBlock skipwhite skipwhite skipempty
 syntax match   javascriptFuncComma             contained /,/


### PR DESCRIPTION
Fixes syn matching of generator declarations of the form: `function *()`