### PR TITLE
Fix javascriptDocParamName rule.

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -123,7 +123,7 @@ syntax keyword javascriptDocTags               contained fires event nextgroup=j
 syntax match   javascriptDocEventRef           contained /\h\w*#\(\h\w*\:\)\?\h\w*/
 
 syntax match   javascriptDocNamedParamType     contained /{.\+}/ nextgroup=javascriptDocParamName skipwhite
-syntax match   javascriptDocParamName          contained /\[\?[0-9a-zA-Z_\.]\+=\?[0-9a-zA-Z_\.]*\]\?/ nextgroup=javascriptDocDesc skipwhite
+syntax match   javascriptDocParamName          contained /\(\[.\{-}\]\|[0-9a-zA-Z_\.]\+\)/ nextgroup=javascriptDocDesc skipwhite
 syntax match   javascriptDocParamType          contained /{.\+}/ nextgroup=javascriptDocDesc skipwhite
 syntax match   javascriptDocA                  contained /\%(#\|\w\|\.\|:\|\/\)\+/ nextgroup=javascriptDocAs skipwhite
 syntax match   javascriptDocAs                 contained /\s*as\s*/ nextgroup=javascriptDocB skipwhite


### PR DESCRIPTION
Fix javascriptDocParamName rule.

before:
![2015-09-24 12 07 18](https://cloud.githubusercontent.com/assets/1061205/10064598/0093b710-62b5-11e5-824d-16caff4baee0.png)


after:
![2015-09-24 12 08 23](https://cloud.githubusercontent.com/assets/1061205/10064601/062cb596-62b5-11e5-9839-17db9b54692c.png)
