### PR TITLE
Fix inline JSDoc links not properly highlighted

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -85,7 +85,7 @@ syntax cluster javascriptComments              contains=javascriptDocComment,jav
 syntax case ignore
 
 syntax region  javascriptDocComment            start="/\*\*"  end="\*/" contains=javascriptDocNotation,javascriptCommentTodo,@Spell fold keepend
-syntax match   javascriptDocNotation           contained / @/ nextgroup=javascriptDocTags
+syntax match   javascriptDocNotation           contained /\W@/ nextgroup=javascriptDocTags
 
 syntax keyword javascriptDocTags               contained constant constructor constructs function ignore inner private public readonly static
 syntax keyword javascriptDocTags               contained const dict expose inheritDoc interface nosideeffects override protected struct


### PR DESCRIPTION
This makes `{@link foo}` work like `{ @link foo }`, note the change in spaces.

Before this fix:
![before - not working](https://cloud.githubusercontent.com/assets/664779/11916112/3ca44e70-a6c8-11e5-9fdc-e19ae5a16fe2.png)

After the fix:
![after - working](https://cloud.githubusercontent.com/assets/664779/11916111/3c8c8880-a6c8-11e5-9b52-96f875bb5453.png)