### PR TITLE
fix highlight for class super when used in expression and comments in class block

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -316,7 +316,7 @@ endif
 syntax match   javascriptObjectMethodName      contained /\k*\ze\_s*(/ nextgroup=javascriptFuncArg skipwhite skipempty
 syntax cluster javascriptObjectMethod          contains=javascriptMethodAccessor,javascriptObjectMethodName
 
-syntax match   javascriptMethodName            contained /\k*/ nextgroup=javascriptFuncArg skipwhite skipempty
+syntax match   javascriptMethodName            contained /[a-zA-Z_$]\k*/ nextgroup=javascriptFuncArg skipwhite skipempty
 " syntax match   javascriptMethodName            contained /[a-zA-Z_$]\k*/ nextgroup=javascriptFuncArg skipwhite skipempty
 syntax region  javascriptMethodName            contained start=/\z(["']\)/  skip=/\\\\\|\\\z1\|\\\n/  end=/\z1\|$/ nextgroup=javascriptFuncArg skipwhite skipempty extend
 syntax match   javascriptMethodAccessor        contained /\(\(set\|get\)\>\|\*\)\ze\_s*\(\[\|\k\|["']\)/ contains=javascriptMethodAccessorWords nextgroup=javascriptMethodName skipwhite
@@ -338,7 +338,7 @@ syntax match   javascriptDefaultAssign         contained /=/ nextgroup=@javascri
 
 "Class
 syntax keyword javascriptClassKeyword          class nextgroup=javascriptClassName,javascriptClassBlock,javascriptClassExtends skipwhite
-syntax keyword javascriptClassSuper            super
+syntax keyword javascriptClassSuper            super nextgroup=@javascriptAfterIdentifier skipwhite skipempty
 syntax match   javascriptClassName             contained /\k\+/ nextgroup=javascriptClassBlock,javascriptClassExtends skipwhite
 syntax match   javascriptClassSuperName        contained /[0-9a-zA-Z_$][0-9a-zA-Z_$\[\]\.]*/ nextgroup=javascriptClassBlock skipwhite
 syntax keyword javascriptClassExtends          contained extends nextgroup=javascriptClassSuperName,javascriptClassExtendsNew skipwhite
@@ -367,7 +367,7 @@ syntax region  javascriptRegexpString          start=+/[^/*]+me=e-1 skip=+\\\\\|
 
 syntax cluster javascriptEventTypes            contains=javascriptEventString,javascriptTemplate,javascriptTagRef,javascriptNumber,javascriptBoolean,javascriptNull
 syntax cluster javascriptOps                   contains=javascriptOpSymbols,javascriptLogicSymbols,javascriptOperator
-syntax cluster javascriptExpression            contains=javascriptArrowFuncDef,javascriptParenExp,@javascriptValue,javascriptObjectLiteral,javascriptFuncKeyword,javascriptYield,javascriptIdentifierName,javascriptRegexpString,@javascriptTypes,@javascriptOps,javascriptGlobal,javascriptGlobalMethod,jsxRegion
+syntax cluster javascriptExpression            contains=javascriptArrowFuncDef,javascriptParenExp,@javascriptValue,javascriptObjectLiteral,javascriptFuncKeyword,javascriptYield,javascriptIdentifierName,javascriptRegexpString,@javascriptTypes,@javascriptOps,javascriptGlobal,javascriptGlobalMethod,jsxRegion,javascriptClassSuper
 syntax cluster javascriptEventExpression       contains=javascriptArrowFuncDef,javascriptParenExp,@javascriptValue,javascriptObjectLiteral,javascriptFuncKeyword,javascriptIdentifierName,javascriptRegexpString,@javascriptEventTypes,@javascriptOps,javascriptGlobal,jsxRegion
 
 syntax region  javascriptLoopParen             contained matchgroup=javascriptParens start=/(/ end=/)/ contains=javascriptVariable,javascriptForOperator,javascriptEndColons,@javascriptExpression nextgroup=javascriptBlock skipwhite skipempty


### PR DESCRIPTION
For example for this snippet 

```javascript
class A {
  // comment not work
  static foo() {
    const a = super.foo();
    return super.foo();
  }

  /**
   *
   * @param {Int} number
   */
  bar() {
    return this.foo(super.bar(), {
      this
    });
  }
}
```

![image](https://cloud.githubusercontent.com/assets/646451/21011106/9b487ad2-bd47-11e6-94c3-e9b8c1e814da.png)

* Comments are not highlighted
* Super is detected as `javascriptReserved`


After this patch:

![image](https://cloud.githubusercontent.com/assets/646451/21011146/e7868a60-bd47-11e6-93c1-683ed7804f8c.png)


I saw https://github.com/othree/yajs.vim/issues/125 said it may cause by conflict plugins. So I tested this in [thinca/vim](https://hub.docker.com/r/thinca/vim/) docker images with only pathogen and yajs installed. And .vimrc as simple as

```
execute pathogen#infect()
syntax on
filetype plugin indent on
```