### PR TITLE
fix exponentiation operator

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -76,7 +76,7 @@ syntax match   javascriptOpSymbols             /-\(-\|=\)\?/ nextgroup=javascrip
 " spread operator
 syntax match   javascriptSpreadOp              contained /\.\.\./ " 1
 " exponentiation operator
-syntax match   javascriptOpSymbol              contained /\(**\|**=\)/ " 2: **, **=
+syntax match   javascriptOpSymbol              contained /\(\*\*\|\*\*=\)/ " 2: **, **=
 
 
 " Comment


### PR DESCRIPTION
Curiously, `**` actually matches zero or one `*`. Vim doesn't warn invalid quantifier in Regex.

Escaping solves the problem.