### PR TITLE
Fix 'async' is not highlighted

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -492,7 +492,7 @@ if exists("did_javascript_hilink")
   HiLink javascriptObjectMethodName     javascriptLabel
 
   HiLink javascriptFuncKeyword          Keyword
-  HiLink javascriptAsyncFunc            Keyword
+  HiLink javascriptAsyncFuncKeyword     Keyword
   HiLink javascriptArrowFunc            Statement
   HiLink javascriptFuncName             Function
   HiLink javascriptFuncArg              Special


### PR DESCRIPTION
I found that `async` keyword is not highlighted. It is highlighted as `javascriptAsyncFuncKeyword`, but not linked to any highlight where color is specified. I corrected this problem.

- Before

<img width="427" alt="2018-03-19 11 43 44" src="https://user-images.githubusercontent.com/823277/37575519-f04aa108-2b6a-11e8-9ab6-79737b7cc61f.png">

- After

<img width="427" alt="2018-03-19 11 44 01" src="https://user-images.githubusercontent.com/823277/37575525-f8ca0d3c-2b6a-11e8-971f-350d81703671.png">
