### PR TITLE
Fix 'await' is not highlighted

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -493,6 +493,7 @@ if exists("did_javascript_hilink")
 
   HiLink javascriptFuncKeyword          Keyword
   HiLink javascriptAsyncFuncKeyword     Keyword
+  HiLink javascriptAwaitFuncKeyword     Keyword
   HiLink javascriptArrowFunc            Statement
   HiLink javascriptFuncName             Function
   HiLink javascriptFuncArg              Special


### PR DESCRIPTION
While #161, I noticed that `await` is not highlighted. I'm not sure that this is a bug, but IMO `await` also should be highlighted because `async` is highlighted. I tried to fix it.

I confirmed

- `await` keyword is correctly highlighted in expression context
- `await` variable name is highlighted as error

<img width="427" alt="2018-03-19 12 19 21" src="https://user-images.githubusercontent.com/823277/37576443-c942ace0-2b6f-11e8-984f-a90a3c794d03.png">
